### PR TITLE
Refactor: use 'perl' instead 'python' dependency

### DIFF
--- a/evince-synctex.sh
+++ b/evince-synctex.sh
@@ -72,8 +72,7 @@ sync() {
 
     echo "Syncing Evince to line $line of '$(basename "$srcpath")' for '$(basename "$pdfpath")'"
 
-    # TODO: Try to remove python dependency
-    pdfuri=file://$(printf '%s' "$pdfpath" | python -c "import urllib.parse;print(urllib.parse.quote(input()))")
+    pdfuri="file://$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "$pdfpath")"
 
     destination=$(gdbus call \
     --session \


### PR DESCRIPTION
Perl is more common than Python on Linux systems.

The problem of using Python that have the command "python" or "python3" (depending on the OS).