### PR TITLE
Refactor: use 'perl' instead 'python' dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The utility is written for Bash, but relies on three external programs:
   * For monitoring the D-Bus _(duhh)_
 * gdbus
   * For sending D-Bus commands to Evince
-* Python 3
-  * Requesting the Evince window for a PDF file, requires the path to it to be formatted as an URI. I currently use Python to perform the required string escapes.
+* Perl
+  * Requesting the Evince window for a PDF file, requires the path to it to be formatted as an URI. I currently use Perl to perform the required string escapes.
 
 
 ### Help

--- a/evince-synctex.sh
+++ b/evince-synctex.sh
@@ -72,8 +72,8 @@ sync() {
 
     echo "Syncing Evince to line $line of '$(basename "$srcpath")' for '$(basename "$pdfpath")'"
 
-    # TODO: Try to remove python dependency
-    pdfuri=file://$(printf '%s' "$pdfpath" | python -c "import urllib.parse;print(urllib.parse.quote(input()))")
+    # TODO: Try to remove perl dependency
+    pdfuri=$(perl -MURI::file -e 'print URI::file->new(<STDIN>)."\n"' <<<"$pdfpath")
 
     destination=$(gdbus call \
     --session \


### PR DESCRIPTION
Perl is often considered more prevalent than Python on Linux systems. One potential issue with using Python arises from the variations in the command name required to execute Python scripts, which can be either "python" or "python3" depending on the operating system in use.