### PR TITLE
Use bash parameter expansion, eliminate `sed` dependence

### DIFF
--- a/evince-synctex.sh
+++ b/evince-synctex.sh
@@ -49,6 +49,12 @@ Examples:
         evince-synctex.sh listen gedit %f +%l
 "
 
+urldecode() {
+    # https://stackoverflow.com/a/37840948
+    local url=${*//+/ }     # replace "+" with " " (space)
+    echo -e "${url//%/\\x}" # replace "%" with "\x" and do hex expansion
+}
+
 sync() {
     if [ ! $# -eq 3 ]; then
         echo -e "Expected exactly 3 arguments for sync, got $#\n$usage" 1>&2
@@ -120,7 +126,9 @@ listen() {
 
             echo "=================================================="
 
-            filename=$(printf '%s' "$filename" | sed 's!%20! !' | head -c -1 | tail -c +9)
+            filename=$(urldecode "$filename")
+            filename=${filename/#\"file:\/\//} # strips the leading '"file://'
+            filename=${filename/%\"/}          # strips the trailing '"'
             echo "Filename: $filename"
             echo "Line number: $linenr"
 

--- a/evince-synctex.sh
+++ b/evince-synctex.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Sync LaTeX editor with Evince
+# shellcheck disable=2206
 
 set -e
 # set -x
@@ -71,7 +73,7 @@ sync() {
     if ! [ -f "$pdfpath" ]; then
         echo "Warning: $pdfpath does not exists." 1>&2
     fi
-    if ! [ $line -eq $line ] 2>/dev/null; then
+    if ! [ "$line" -eq "$line" ] 2>/dev/null; then
         echo -e "<line> should be a number, got $line\n$usage" 1>&2
         exit 1
     fi
@@ -95,7 +97,7 @@ sync() {
 
     gdbus call \
     --session \
-    -d $destination \
+    -d "$destination" \
     -o /org/gnome/evince/Window/0 \
     -m org.gnome.evince.Window.SyncView \
     "$srcpath" "($line, 1)" 0 > /dev/null
@@ -105,7 +107,7 @@ sync() {
 }
 
 listen() {
-    cmd=${@:-'code --goto %f:%l'}
+    cmd=${*:-'code --goto %f:%l'}
     echo "Listening to Evince SyncSource requests. Executing '$cmd' on new signals"
     # echo "Running command '$cmd' on SyncSource request"
 
@@ -119,9 +121,9 @@ listen() {
             exc_cmd=($cmd)
             filename=""
             linenr=""
-        elif [ ${parts[0]} == string ]; then
+        elif [ "${parts[0]}" == string ]; then
             filename=${parts[1]}
-        elif [ ${parts[0]} == int32 ] && [ -z "$linenr" ]; then
+        elif [ "${parts[0]}" == int32 ] && [ -z "$linenr" ]; then
             linenr=${parts[1]}
 
             echo "=================================================="
@@ -138,7 +140,7 @@ listen() {
                 exc_cmd[i]=${exc_cmd[$i]//%f/"$filename"}
             done
 
-            echo "Executing: '${exc_cmd[@]}'"
+            echo "Executing: '${exc_cmd[*]}'"
 
             "${exc_cmd[@]}" < /dev/null
         fi

--- a/evince-synctex.sh
+++ b/evince-synctex.sh
@@ -134,8 +134,8 @@ listen() {
 
             for i in "${!exc_cmd[@]}"; do
                 # Do all replacements here
-                exc_cmd[$i]=$(echo "${exc_cmd[$i]}" | sed "s/%l/$linenr/")
-                exc_cmd[$i]=$(echo "${exc_cmd[$i]}" | sed 's!%f!'"$filename"'!')
+                exc_cmd[i]=${exc_cmd[$i]//%l/"$linenr"}
+                exc_cmd[i]=${exc_cmd[$i]//%f/"$filename"}
             done
 
             echo "Executing: '${exc_cmd[@]}'"


### PR DESCRIPTION
This is more robust and more portable, compared to the previous `sed` and byte-stripping implementations. Also added some minor cleanup along the way, following the instructions of [shellcheck](https://github.com/koalaman/shellcheck).

Thank you for this wonderful script!